### PR TITLE
2D Registration

### DIFF
--- a/fireants/io/image.py
+++ b/fireants/io/image.py
@@ -66,6 +66,10 @@ class Image:
     def load_file(cls, image_path:str, *args, **kwargs) -> 'Image':
         itk_image = sitk.ReadImage(image_path)
         return cls(itk_image, *args, **kwargs)
+    
+    @property
+    def shape(self):
+        return self.array.shape
 
 
 class BatchedImages:

--- a/fireants/io/image.py
+++ b/fireants/io/image.py
@@ -87,7 +87,7 @@ class BatchedImages:
         else:
             raise ValueError("All images must have the same shape")
         self.n_images = len(self.images)
-        self.interpolate_mode = 'bilinear' if self.images[0] == 2 else 'trilinear'
+        self.interpolate_mode = 'bilinear' if len(self.images[0].shape) == 4 else 'trilinear'
 
     def __call__(self):
         # get batch of images

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ description = "FireANTs: Adaptive Riemannian Optimization for Multi-Scale Diffeo
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "torch==1.13.1",
-    "SimpleITK==2.2.1", 
-    "nibabel==4.0.2",
+    "torch>=1.13.1",
+    "SimpleITK>=2.2.1", 
+    "nibabel>=4.0.2",
     "numpy", "scipy", "scikit-image", "matplotlib",
-    "typing", "tqdm", "pandas==1.3.5", "nibabel==4.0.2",
+    "typing", "tqdm", "pandas>=1.3.5"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ description = "FireANTs: Adaptive Riemannian Optimization for Multi-Scale Diffeo
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "torch>=1.13.1",
-    "SimpleITK>=2.2.1", 
-    "nibabel>=4.0.2",
+    "torch==1.13.1",
+    "SimpleITK==2.2.1", 
+    "nibabel==4.0.2",
     "numpy", "scipy", "scikit-image", "matplotlib",
-    "typing", "tqdm", "pandas>=1.3.5"
+    "typing", "tqdm", "pandas==1.3.5"
 ]


### PR DESCRIPTION
With the proposed changes I am able to run the code using 2D histopathology patches.
Following code executes flawlessly. Thanks @rohitrango  for your support and help. 

I am  attaching a sample run output for your reference. 

**Loading the Images**

```python
sitk_patches_moving = [sitk.GetImageFromArray(p) for p in patches_moving]
sitk_patches_fixed = [sitk.GetImageFromArray(p) for p in patches_fixed]
fire_ants_moving = Image(sitk_patches_moving[9])
fire_ants_fixed = Image(sitk_patches_fixed[9])

print(f"Shape of the patches are {patches_moving[9].shape}")

b1 = BatchedImages([fire_ants_moving])
b2 = BatchedImages([fire_ants_fixed])
```

**Output**

```python
Shape of the patches are (2452, 2048)
```

**Affine Registration**
```python
scales = [4, 2, 1]  # scales at which to perform registration
iterations = [200, 300, 20]
optim = "Adam"
lr = 3e-3
loss_type = "cc"
loss_device = "cuda:1"
affine = AffineRegistration(
    scales,
    iterations,
    b1,
    b2,
    optimizer=optim,
    optimizer_lr=lr,
    cc_kernel_size=5,
    loss_type=loss_type,
    loss_device=loss_device,
)
transformed_images = affine.optimize(save_transformed=True)
```
**Output:**

```python
scale: 4, iter: 8/200, loss: -905626.812500:   4%|▍         | 9/200 [00:00<00:01, 122.91it/s]
scale: 2, iter: 22/300, loss: -1584069.500000:   8%|▊         | 23/300 [00:00<00:02, 131.41it/s]
scale: 1, iter: 8/20, loss: -318552.468750:  45%|████▌     | 9/20 [00:00<00:00, 46.36it/s]
```

**Greedy Registration**
```python
reg = GreedyRegistration(
    scales=[4, 2, 1],
    iterations=[200, 100, 25],
    fixed_images=b1,
    moving_images=b2,
    cc_kernel_size=5,
    deformation_type="geodesic",
    smooth_grad_sigma=1,
    optimizer="Adam",
    optimizer_lr=0.5,
    init_affine=affine.get_affine_matrix().detach(),
)
reg.optimize(save_transformed=False)
```

**Output**
```python
scale: 4, iter: 9/200, loss: -218369.748777:   4%|▍         | 9/200 [00:00<00:01, 123.72it/s]
scale: 2, iter: 9/100, loss: -33106.694943:   9%|▉         | 9/100 [00:00<00:01, 63.13it/s]
scale: 1, iter: 9/25, loss: -879.720432:  36%|███▌      | 9/25 [00:00<00:00, 22.01it/s] 
```


