### PR TITLE
Opt parse defaults

### DIFF
--- a/scripts/fireantsRegistration
+++ b/scripts/fireantsRegistration
@@ -5,6 +5,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
+import textwrap
 import torch
 import logging
 from typing import List, Optional, Union, Tuple
@@ -44,49 +45,126 @@ def is_compatible_next_transform(prev_transforms: List[str], transform_type: str
     return all([t in compat_table[transform_type] for t in prev_transforms])
 
 def parse_args():
-    class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
-        def format_help(self):
-            return show_help(None)
+    class RawDefaultsHelpFormatter(
+        argparse.RawTextHelpFormatter, argparse.ArgumentDefaultsHelpFormatter
+    ):
+        pass
 
-    parser = argparse.ArgumentParser(description='FireANTs Registration Tool', formatter_class=CustomHelpFormatter)
+    parser = argparse.ArgumentParser(formatter_class=RawDefaultsHelpFormatter, add_help = False,
+                                     description='''FireANTs Registration Tool
+
+    This tool provides a command-line interface for medical image registration, similar to ANTs' antsRegistration.
+
+    Example Usage:
+    ------------
+    ./fireantsRegistration \\
+    --output demo_output/fireantsTransform \\
+    --initial-moving-transform [fixed.nii.gz,moving.nii.gz,2] \\
+    --transform Rigid[3e-2] \\
+    --metric MI[fixed.nii.gz,moving.nii.gz,gaussian,16] \\
+    --convergence [100x50x25x10,1e-6,10] \\
+    --shrink-factors 8x4x2x1 \\
+    --transform Affine[3e-2] \\
+    --metric CC[fixed.nii.gz,moving.nii.gz,5] \\
+    --convergence [100x50x25x10,1e-4,10] \\
+    --shrink-factors 8x4x2x1 \\
+    --transform SyN[0.2] \\
+    --metric MSE[fixed.nii.gz,moving.nii.gz] \\
+    --convergence [100x70x50x20,1e-4,10] \\
+    --shrink-factors 8x4x2x1
+
+    Notes:
+    -----
+    1. Transforms must be specified in order: Rigid -> Affine -> SyN/Greedy
+    2. Each transform requires its own metric, convergence, and shrink-factors
+    3. Number of shrink factors must match number of iterations in convergence
+    4. For SyN/Greedy registration, smooth_warp_sigma and smooth_grad_sigma can be specified
+    either in the transform parameters or as command-line arguments
+    ''')
+
     # Required arguments
-    parser.add_argument('--output', type=str, required=True,
-                      help='Output prefix and warped image path [prefix,warped_image]')
-    parser.add_argument('--winsorize-image-intensities', type=str, default=None,
-                      help='Winsorize image intensities [lower,upper]')
-    parser.add_argument('--initial-moving-transform', type=str,
-                      help='Initial transform [fixed,moving,type] or transform file')
+    required_parser = parser.add_argument_group("Required arguments")
+    required_parser.add_argument('--output', type=str, required=True,
+                    help='Output prefix and warped image path [prefix,warped_image]')
+    required_parser.add_argument('--winsorize-image-intensities', type=str, default=None,
+                    help='Winsorize image intensities [lower,upper]. Parameters can be quantiles [0,1] or percentiles [0,100]')
+    required_parser.add_argument('--initial-moving-transform', type=str, required=True,
+                    help=textwrap.dedent('''\
+                    Initial transform [fixed,moving,type]. Type can be:
+                            - 1: match by center of mass
+                            - 2: match by mid-point (geometric center of images)
+                            - 3: match by point of origin
+                    If not provided, the default initial transform is Identity.
+                    '''))
     # these are all the rigid/affine/deformable params
-    parser.add_argument('--transform', type=str, action='append', required=True,
-                      help='Transform type and parameters [type,params]. Can be specified multiple times.')
-    parser.add_argument('--metric', type=str, action='append', required=True,
-                      help='Similarity metric [fixed,moving,weight,params]. One per transform.')
-    parser.add_argument('--convergence', type=str, action='append', required=True,
-                      help='Convergence parameters [iterations,tolerance,window]. One per transform.')
-    parser.add_argument('--shrink-factors', type=str, action='append', required=True,
-                      help='Shrink factors for multi-resolution. One per transform.')
+    required_parser.add_argument('--transform', type=str, required=True, action='append',
+                    help=textwrap.dedent('''\
+                    Transform type and parameters, as Type[params]. Can be specified multiple times for multi-stage
+                    registration, with stages run in order. Supported transforms:
+                        - Rigid[gradient_step,optimizer=Adam,scaling=False]
+                        - Affine[gradient_step,optimizer=Adam]
+                        - SyN[gradient_step,optimizer=Adam,smooth_warp_sigma,smooth_grad_sigma]
+                        - Greedy[gradient_step,optimizer=Adam,smooth_warp_sigma,smooth_grad_sigma]
 
-    # unused args (kept for compatibility only)
-    parser.add_argument('--use-histogram-matching', type=int, default=0,
-                      help='Use histogram matching (0 or 1)')
-    parser.add_argument('--smoothing-sigmas', type=str, action='append', required=False,
-                      help='Smoothing sigmas for multi-resolution. One per transform (ignored, kept for compatibility).')
-    parser.add_argument('--interpolation', type=str, default='Linear',
-                      choices=['Linear', 'NearestNeighbor'],
-                      help='Interpolation type for warped image')
-    # extra args
-    parser.add_argument('--smooth_warp_sigma', type=float, default=0.25, help='Smoothing sigma for the warp field')
-    parser.add_argument('--smooth_grad_sigma', type=float, default=0.5, help='Smoothing sigma for the gradient field')
-    parser.add_argument('--normalize-image-intensities', action='store_true', help="Normalize image intensities to [0,1]")
+                    Transform parameters:
+                        gradient_step: step size for the optimizer, typically 0.1 to 0.25
+
+                        optimizer: optimizer to use, default is Adam
+
+                        smooth_warp_sigma: smoothing sigma for the warp field (for SyN/Greedy)
+                        smooth_grad_sigma: smoothing sigma for the gradient field (for SyN/Greedy)
+                    '''))
+    required_parser.add_argument('--metric', type=str, required=True, action='append',
+                    help=textwrap.dedent('''\
+                    Similarity metric [fixed,moving,weight,params]. One per transform.
+
+                    Supported metrics
+                        - MSE[fixed,moving] or MeanSquares[fixed,moving] or L2[fixed,moving] (mean squared error)
+                        - CC[fixed,moving,kernel_size=5] (cross-correlation)
+                        - MI[fixed,moving,kernel_type=gaussian,num_bins=32] (mutual information)
+                        - Custom[fixed,moving,module.path.ClassName,param1=value1,...] (user-defined metric)
+                    '''))
+    required_parser.add_argument('--convergence', type=str, required=True, action='append',
+                    help=textwrap.dedent('''\
+                    Convergence parameters [iterations,tolerance,window]. One per transform, containing:
+                        - iterations: number per level, in format MxNxP.
+                        - tolerance: convergence tolerance, larger values converge faster.
+                        - window: size of moving window over which to check for convergence.'''))
+    required_parser.add_argument('--shrink-factors', type=str, required=True, action='append',
+                    help=textwrap.dedent('''\
+                    Shrink factors for multi-resolution registration. One per transform. Shrink factors are integers in
+                    the format QxRxS, eg 4x2x1. The number of shrink factors must match the number of levels in the
+                    convergence arg'''))
 
     # device args
-    parser.add_argument('--device', type=str, default='cuda:0',
-                      help='Device to run the registration on. Default is cuda:0.')
+    device_parser = parser.add_argument_group("Device arguments")
+    device_parser.add_argument('--device', type=str, default='cuda:0', help='Device to use for registration.')
 
-    parser.add_argument('-x', '--mask', type=str,
-                      help='Mask image or [fixed_mask,moving_mask]')
-    parser.add_argument('--verbose', action='store_true',
-                      help='Enable verbose output')
+    # extra args
+    optional_parser = parser.add_argument_group("General optional arguments")
+    optional_parser.add_argument('--smooth_warp_sigma', type=float, default=0.25, help='Smoothing sigma for the warp field. '
+                                 'Only used if not provided in the transform parameters')
+    optional_parser.add_argument('--smooth_grad_sigma', type=float, default=0.5, help='Smoothing sigma for the gradient field. '
+                                 'Only used if not provided in the transform parameters')
+    optional_parser.add_argument('--normalize-image-intensities', action='store_true',
+                                 help="Normalize image intensities to [0,1]")
+    optional_parser.add_argument('-x', '--mask', type=str, help='Mask image or [fixed_mask,moving_mask].')
+    optional_parser.add_argument('--verbose', action='store_true', help='Enable verbose output')
+    optional_parser.add_argument('-h', '--help', action='help', help='Show this help message and exit')
+
+    # unused args (kept for compatibility only)
+    unused_parser = parser.add_argument_group("Unused arguments (some may be implemented in the future)")
+    unused_parser.add_argument('--use-histogram-matching', type=int, default=0, help='Use histogram matching (0 or 1)')
+    unused_parser.add_argument('--smoothing-sigmas', type=str, action='append', required=False, help='Smoothing sigmas for '
+                        'multi-resolution. One per transform (ignored, kept for compatibility).')
+    unused_parser.add_argument('--interpolation', type=str, default='Linear',
+                    choices=['Linear', 'NearestNeighbor'],
+                    help='Interpolation type for warped image')
+
+    if len(sys.argv) == 1:
+        parser.print_usage()
+        print(f"\nRun {os.path.basename(sys.argv[0])} --help for more information")
+        sys.exit(1)
 
     return parser.parse_args()
 
@@ -277,114 +355,6 @@ def load_image(path: str, is_mask: bool = False, device: str = 'cuda:0') -> Imag
         logger.error(f"Error loading image {path}: {e}")
         sys.exit(1)
 
-def show_help(args: argparse.Namespace):
-    ''' show a verbose help message '''
-    help_text = """
-FireANTs Registration Tool
-=========================
-
-This tool provides a command-line interface for medical image registration, similar to ANTs' antsRegistration.
-
-Required Arguments:
-------------------
---output [prefix,warped_image]
-    Output prefix for transforms and warped image path. If only prefix is provided, warped image will be saved as prefix_warped.nii.gz
-
---transform [type,params]
-    Transform type and parameters. Can be specified multiple times for multi-stage registration.
-    Supported types:
-    - Rigid[gradient_step,optimizer=Adam,scaling=False]
-    - Affine[gradient_step,optimizer=Adam]
-    - SyN[gradient_step,optimizer=Adam,smooth_warp_sigma,smooth_grad_sigma]
-    - Greedy[gradient_step,optimizer=Adam,smooth_warp_sigma,smooth_grad_sigma]
-
---metric [type,fixed,moving,params]
-    Similarity metric for registration. Must be specified once per transform.
-    Supported types:
-    - MSE[fixed,moving] or MeanSquares[fixed,moving] or L2[fixed,moving]
-    - CC[fixed,moving,kernel_size=5]
-    - MI[fixed,moving,kernel_type=gaussian,num_bins=32]
-    - Custom[fixed,moving,module.path.ClassName,param1=value1,...]
-
---convergence [iterations,tolerance,window]
-    Convergence parameters. Must be specified once per transform.
-    Format: [100x50x25x10,1e-6,10] where:
-    - iterations: comma-separated list of iterations per scale
-    - tolerance: convergence tolerance
-    - window: number of iterations to check for convergence
-
---shrink-factors [factors]
-    Shrink factors for multi-resolution optimization. Must be specified once per transform.
-    Format: 8x4x2x1 (must match number of iterations in --convergence)
-
-Optional Arguments:
------------------
---initial-moving-transform [fixed,moving,type]
-    Initial transform to align images before registration.
-    type can be:
-    - 1: match by center of mass
-    - 2: match by mid-point
-    - 3: match by point of origin
-
---winsorize-image-intensities [lower,upper]
-    Clip image intensities to specified quantiles [0,1] or percentiles [0,100]
-
---normalize-image-intensities
-    Normalize image intensities to [0,1] range
-
---mask [fixed_mask,moving_mask]
-    Mask images for registration. Must provide both fixed and moving masks.
-
---device [cuda:0]
-    Device to run registration on. Default is cuda:0.
-
---smooth_warp_sigma [0.25]
-    Smoothing sigma for the warp field (for SyN/Greedy)
-
---smooth_grad_sigma [0.5]
-    Smoothing sigma for the gradient field (for SyN/Greedy)
-
---verbose
-    Enable verbose output
-
-Deprecated/Unused Options (kept for compatibility):
------------------------------------------------
---use-histogram-matching [0]
-    Not implemented yet, will be ignored
-
---smoothing-sigmas [sigmas]
-    Not used, kept for compatibility with ANTs
-
---interpolation [Linear]
-    Not used, kept for compatibility with ANTs
-
-Example Usage:
-------------
-./fireantsRegistration \\
-  --output demo_output/fireantsTransform \\
-  --initial-moving-transform [fixed.nii.gz,moving.nii.gz,2] \\
-  --transform Rigid[3e-2] \\
-  --metric MI[fixed.nii.gz,moving.nii.gz,gaussian,16] \\
-  --convergence [100x50x25x10,1e-6,10] \\
-  --shrink-factors 8x4x2x1 \\
-  --transform Affine[3e-2] \\
-  --metric CC[fixed.nii.gz,moving.nii.gz,5] \\
-  --convergence [100x50x25x10,1e-4,10] \\
-  --shrink-factors 8x4x2x1 \\
-  --transform SyN[0.2] \\
-  --metric MSE[fixed.nii.gz,moving.nii.gz] \\
-  --convergence [100x70x50x20,1e-4,10] \\
-  --shrink-factors 8x4x2x1
-
-Notes:
------
-1. Transforms must be specified in order: Rigid -> Affine -> SyN/Greedy
-2. Each transform requires its own metric, convergence, and shrink-factors
-3. Number of shrink factors must match number of iterations in convergence
-4. For SyN/Greedy registration, smooth_warp_sigma and smooth_grad_sigma can be specified
-   either in the transform parameters or as command-line arguments
-"""
-    print(help_text)
 
 def main():
     args = parse_args()

--- a/scripts/fireantsRegistration
+++ b/scripts/fireantsRegistration
@@ -221,25 +221,10 @@ def parse_metric(metric_str: str) -> Tuple[str, List[Union[str, float]]]:
 
     return metric_type, pd
 
-def prepare_prev_transform(prev_transform, prev_transform_type, transform_type, default_device='cuda:0', default_dims=3):
-    ''' prepare the previous transform for the next transform.
-
-        device and dimensionality are taken from the previous transform unless it is None,
-        in which care the default parameters are used.
-
-    '''
+def prepare_prev_transform(prev_transform, prev_transform_type, transform_type):
+    ''' prepare the previous transform for the next transform. '''
     if prev_transform_type is None:
-        # return identity transform
-        if transform_type == 'Rigid':
-            return {
-                'init_translation': torch.zeros(default_dims, device = default_device),
-                'init_moment': torch.eye(default_dims, device=default_device),
-            }
-        else:
-            key = 'init_rigid' if transform_type == 'Affine' else 'init_affine'
-            return {
-                key: torch.eye(default_dims, device=default_device),
-            }
+        return {}
     elif prev_transform_type == 'Moments':
         if transform_type == 'Rigid':
             return {
@@ -520,8 +505,7 @@ def main():
         iterations, tolerance, window = parse_convergence(conv_str)
 
         # gather parameters to pass to the registration from previous step
-        prev_transform_params = prepare_prev_transform(prev_transform, prev_transform_type, transform_type,
-                                                       default_device=args.device, default_dims=fixed_image.dims)
+        prev_transform_params = prepare_prev_transform(prev_transform, prev_transform_type, transform_type)
         merged_params = {**prev_transform_params, **transform_params, **metric_params}
         merged_params['tolerance'] = tolerance
         merged_params['max_tolerance_iters'] = window

--- a/scripts/fireantsRegistration
+++ b/scripts/fireantsRegistration
@@ -47,7 +47,7 @@ def parse_args():
     class CustomHelpFormatter(argparse.RawDescriptionHelpFormatter):
         def format_help(self):
             return show_help(None)
-    
+
     parser = argparse.ArgumentParser(description='FireANTs Registration Tool', formatter_class=CustomHelpFormatter)
     # Required arguments
     parser.add_argument('--output', type=str, required=True,
@@ -87,7 +87,7 @@ def parse_args():
                       help='Mask image or [fixed_mask,moving_mask]')
     parser.add_argument('--verbose', action='store_true',
                       help='Enable verbose output')
-    
+
     return parser.parse_args()
 
 def preprocess_images(fixed_image, moving_image, normalize_image_intensities, winsorize_image_intensities):
@@ -104,8 +104,8 @@ def preprocess_images(fixed_image, moving_image, normalize_image_intensities, wi
     return fixed_image, moving_image
 
 def winsorize(array: torch.Tensor, w1: float, w2: float) -> torch.Tensor:
-    ''' winsorize the image intensities 
-    
+    ''' winsorize the image intensities
+
     doing this in numpy because torch percentile breaks for large tensors
     '''
     nparray = array.cpu().numpy()
@@ -119,7 +119,7 @@ def winsorize(array: torch.Tensor, w1: float, w2: float) -> torch.Tensor:
         raise ValueError(f"Unsupported winsorize parameters: {w1}, {w2}")
     nparray[nparray < w1] = w1
     nparray[nparray > w2] = w2
-    nparray = (nparray - w1) 
+    nparray = (nparray - w1)
     return torch.from_numpy(nparray).to(array.device).to(array.dtype)
 
 def parse_moment_transform(transform_type: str) -> Tuple[bool, str]:
@@ -221,9 +221,26 @@ def parse_metric(metric_str: str) -> Tuple[str, List[Union[str, float]]]:
 
     return metric_type, pd
 
-def prepare_prev_transform(prev_transform, prev_transform_type, transform_type):
-    ''' prepare the previous transform for the next transform '''
-    if prev_transform_type == 'Moments':
+def prepare_prev_transform(prev_transform, prev_transform_type, transform_type, default_device='cuda:0', default_dims=3):
+    ''' prepare the previous transform for the next transform.
+
+        device and dimensionality are taken from the previous transform unless it is None,
+        in which care the default parameters are used.
+
+    '''
+    if prev_transform_type is None:
+        # return identity transform
+        if transform_type == 'Rigid':
+            return {
+                'init_translation': torch.zeros(default_dims, device = default_device),
+                'init_moment': torch.eye(default_dims, device=default_device),
+            }
+        else:
+            key = 'init_rigid' if transform_type == 'Affine' else 'init_affine'
+            return {
+                key: torch.eye(default_dims, device=default_device),
+            }
+    elif prev_transform_type == 'Moments':
         if transform_type == 'Rigid':
             return {
                 'init_translation': prev_transform.get_rigid_transl_init().detach(),
@@ -254,7 +271,7 @@ def prepare_prev_transform(prev_transform, prev_transform_type, transform_type):
         }
     else:
         raise ValueError(f"Unsupported transform type combination: {prev_transform_type} -> {transform_type}")
-                
+
 def parse_convergence(conv_str: str) -> Tuple[List[int], float, int]:
     """Parse convergence string like '[1000x500x250x100,1e-6,10]'."""
     iterations = [int(x) for x in conv_str.split('[')[1].split(',')[0].split('x')]
@@ -403,7 +420,7 @@ def main():
         if not is_compatible_next_transform(prev_transforms, transform_type):
             logger.error(f"Transforms must be in order, {transform_str} is not compatible with {prev_transforms}")
         prev_transforms.append(transform_type)
-    
+
     # check if number of scales are consistent in convergence, shrink_factors
     for i, (conv_str, shrink_str) in enumerate(zip(args.convergence, args.shrink_factors)):
         iterations, tolerance, window = parse_convergence(conv_str)
@@ -415,12 +432,12 @@ def main():
     # TODO: implement histogram matching
     if args.use_histogram_matching:
         logger.warning("Histogram matching not implemented yet, ignoring this parameter...")
-    
+
     # Set up logging
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
         logger.setLevel(logging.DEBUG)
-    
+
     # Parse output paths
     try:
         output_prefix, warped_image_file = args.output.split(',')
@@ -430,7 +447,7 @@ def main():
         # maybe only prefix was provided
         output_prefix = args.output
         warped_image_file = output_prefix + "_warped.nii.gz"
-    
+
     # Load masks if provided
     if args.mask:
         if ',' in args.mask:
@@ -456,7 +473,7 @@ def main():
         # initialize the batch
         fixed_batch = BatchedImages([fixed_image])
         moving_batch = BatchedImages([moving_image])
-        # initialize the transform type    
+        # initialize the transform type
         moments, ori = parse_moment_transform(transform_type)
         # run moment matching
         moments_reg = MomentsRegistration(
@@ -474,7 +491,7 @@ def main():
     # initialize previous transform
     prev_transform = moments_reg
     prev_transform_type = 'Moments' if moments_reg is not None else None
-    
+
     # Process each transform in sequence
     for i, (transform_str, metric_str, conv_str, shrink_str) in enumerate(zip(args.transform, args.metric, args.convergence, args.shrink_factors)):
     # Parse multi-resolution parameters
@@ -503,7 +520,8 @@ def main():
         iterations, tolerance, window = parse_convergence(conv_str)
 
         # gather parameters to pass to the registration from previous step
-        prev_transform_params = prepare_prev_transform(prev_transform, prev_transform_type, transform_type)
+        prev_transform_params = prepare_prev_transform(prev_transform, prev_transform_type, transform_type,
+                                                       default_device=args.device, default_dims=fixed_image.dims)
         merged_params = {**prev_transform_params, **transform_params, **metric_params}
         merged_params['tolerance'] = tolerance
         merged_params['max_tolerance_iters'] = window
@@ -544,7 +562,7 @@ def main():
         else:
             logger.error(f"Unsupported transform type: {transform_type}")
             sys.exit(1)
-        
+
         # Run registration
         logger.info(f"Starting Step {i+1}/{len_transform}: {transform_type} registration...")
         reg.optimize(save_transformed=False)
@@ -554,21 +572,21 @@ def main():
         del prev_transform
         prev_transform = reg
         prev_transform_type = transform_type
-        
+
         # # Save results
         # output_dir = Path(output_prefix).parent
         # output_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # # Save transformed image
         # moved_image = reg.evaluate(fixed_batch, moving_batch)
         # reg.save_moved_images(moved_image, warped_image)
         # logger.info(f"Saved warped image to {warped_image}")
-        
+
         # # Save transform
         # transform_path = f"{output_prefix}0GenericAffine.mat"
         # reg.save_as_ants_transforms(transform_path)
         # logger.info(f"Saved transform to {transform_path}")
-        
+
         # Save inverse transform if available
         # if hasattr(reg, 'get_inverse_warped_coordinates'):
         #     try:
@@ -578,7 +596,7 @@ def main():
         #     except NotImplementedError:
         #         logger.warning("Inverse transform not implemented for this registration type")
         # logger.info("Registration completed successfully")
-    
+
     # create output directory
     parent_path = Path(warped_image_file).parent
     parent_path.mkdir(parents=True, exist_ok=True)
@@ -587,7 +605,7 @@ def main():
     final_moving_image = load_image(moving_path, device=args.device)
     final_moving_batch = BatchedImages([final_moving_image])
     moved_image = reg.evaluate(fixed_batch, final_moving_batch)
-    # save 
+    # save
     moved_image = FakeBatchedImages(moved_image, fixed_batch)
     moved_image.write_image(warped_image_file)
     logger.info(f"Saved warped image to {warped_image_file}")
@@ -602,6 +620,6 @@ def main():
 
 
 if __name__ == '__main__':
-    main() 
+    main()
 
 


### PR DESCRIPTION
Switching up the argparse behavior a bit.

The main purpose of this is to simplify the arg documentation. Defaults are automatically printed, so if you change a default like

```
    optional_parser.add_argument('--smooth_grad_sigma', type=float, 
    default=0.5, help='Smoothing sigma for the gradient field. '
    'Only used if not provided in the transform parameters')
```   

you only have to change default=0.5 to default=new_value, you don't separately have to edit the help message.    

Grouping of args is done via argument groups.

I also changed help to print short usage if run with no args, and long help if run with `-h` or `--help`.