### PR TITLE
Relax SimpleITK version pin to support Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,10 @@ authors = [
 ]
 description = "FireANTs: Adaptive Riemannian Optimization for Multi-Scale Diffeomorphic Registration"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "torch>=2.3.0",
-    "SimpleITK==2.2.1", 
+    "SimpleITK>=2.2.1", 
     "nibabel",
     "numpy", "scipy", "scikit-image", "matplotlib",
     "typing", "tqdm", "pandas", "hydra-core",


### PR DESCRIPTION
- Change SimpleITK==2.2.1 to SimpleITK>=2.2.1, allowing pip to resolve a compatible version for Python 3.12+ (requires >=2.3.1)
- Update requires-python from >=3.7 to >=3.8 (aligned with torch>=2.3.0)
- Add Python 3.12 to CI test matrix

Closes #101