### PR TITLE
feat(losses): add optional fused_lncc LNCC backend (loss_type='fused_…

### DIFF
--- a/fireants/losses/fused_lncc_backend.py
+++ b/fireants/losses/fused_lncc_backend.py
@@ -1,0 +1,104 @@
+"""Optional LNCC backend backed by the standalone ``fused_lncc`` CUDA kernel.
+
+    pip install fused_lncc --no-build-isolation   # needs PyTorch + a CUDA toolchain; see its README
+    reg = GreedyRegistration(..., loss_type='fused_lncc')   # falls back to 'cc' if not installed
+"""
+import warnings
+from typing import List, Optional, Union
+
+import torch
+from torch import nn
+
+try:
+    from fused_lncc import fused_lncc_loss
+except ImportError as e:  # the loss_type dispatcher catches this and falls back to 'cc'
+    raise ImportError("fused_lncc is not installed; `pip install fused_lncc`") from e
+
+_SUPPORTED_KERNEL_SIZES = (3, 5, 7, 9)
+
+
+class _ScaleGrad(torch.autograd.Function):
+    """Identity forward; scales the gradient by a constant on the backward pass."""
+
+    @staticmethod
+    def forward(ctx, x, factor):
+        ctx.factor = factor
+        return x
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad * ctx.factor, None
+
+
+class FusedLNCCLoss(nn.Module):
+    """Rectangular LNCC via the fused_lncc kernel, matching ``FusedLocalNormalizedCrossCorrelationLoss``.
+
+    Faster and lighter than the cuDNN path, but narrower: 3D, rectangular window, odd kernel in
+    {3, 5, 7, 9}, mean reduction, gradient to ``pred`` only, single GPU (no grid-parallel sharding).
+    Other configurations
+    (gaussian, masking, sum/none reduction, symmetric/SyN gradients) raise; use ``loss_type='fusedcc'``.
+
+    The gradient is exact (cosine 1.0 vs MONAI), unlike fusedcc's default ``use_ants_gradient=True``
+    ANTs approximation. The denominator regularizer differs from fusedcc only in near-constant
+    windows, which shifts the loss value there but not the gradient or the registration result.
+    """
+
+    def __init__(
+        self,
+        spatial_dims: int = 3,
+        kernel_size: Union[int, List[int]] = 3,
+        reduction: str = "mean",
+        smooth_dr: float = 1e-5,
+        kernel_type: str = "rectangular",
+        masked: bool = False,
+        use_ants_gradient: Optional[bool] = None,
+        **kwargs,  # absorb fusedcc args this kernel does not use (smooth_nr, use_separable, ...)
+    ) -> None:
+        super().__init__()
+        if use_ants_gradient:
+            warnings.warn("fused_lncc always uses the exact gradient; use_ants_gradient=True is ignored.")
+        if spatial_dims != 3:
+            raise NotImplementedError(f"fused_lncc supports 3D only (got {spatial_dims}); use loss_type='fusedcc'")
+        if kernel_type != "rectangular":
+            raise NotImplementedError(f"fused_lncc supports rectangular only (got '{kernel_type}'); use loss_type='fusedcc'")
+        if reduction != "mean":
+            raise NotImplementedError(f"fused_lncc supports reduction='mean' only (got '{reduction}'); use loss_type='fusedcc'")
+        if masked:
+            raise NotImplementedError("fused_lncc does not support masked mode; use loss_type='fusedcc'")
+
+        # kernel_size may be a single int or one per multi-resolution scale.
+        self.kernel_size_list = list(kernel_size) if isinstance(kernel_size, (list, tuple)) else None
+        for k in self.kernel_size_list or [kernel_size]:
+            if k not in _SUPPORTED_KERNEL_SIZES:
+                raise ValueError(f"fused_lncc supports kernel_size in {_SUPPORTED_KERNEL_SIZES}, got {k}")
+        self.kernel_size = self.kernel_size_list[0] if self.kernel_size_list else kernel_size
+        self.smooth_dr = float(smooth_dr)
+
+    # multi-scale hooks called by the registration framework
+    def set_scales(self, scales) -> None:
+        self.scales = scales
+        if self.kernel_size_list:
+            assert len(self.kernel_size_list) == len(scales), "kernel_size list must match the number of scales"
+
+    def set_iterations(self, iterations) -> None:
+        self.iterations = iterations
+
+    def set_current_scale_and_iterations(self, scale, iters) -> None:
+        if self.kernel_size_list:
+            self.kernel_size = self.kernel_size_list[self.scales.index(scale)]
+
+    def get_image_padding(self) -> int:
+        return (self.kernel_size - 1) // 2
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        if pred.shape != target.shape:
+            raise ValueError(f"pred and target must have the same shape, got {pred.shape} vs {target.shape}")
+        # The kernel differentiates w.r.t. `pred` only; route the grad-requiring image there.
+        if pred.requires_grad and target.requires_grad:
+            raise NotImplementedError("fused_lncc has a pred-only gradient; symmetric/SyN is unsupported, use loss_type='fusedcc'")
+        if target.requires_grad and not pred.requires_grad:
+            pred, target = target, pred
+        # Kernel returns 1 - mean(ncc); -1.0 matches fusedcc's -mean(ncc) sign. fusedcc's gradient is
+        # numel/kernel_vol larger than the true mean gradient, so rescale to match it (same lr converges alike).
+        loss = fused_lncc_loss(pred, target, self.kernel_size, self.smooth_dr)
+        return _ScaleGrad.apply(loss, pred.numel() / self.kernel_size ** 3) - 1.0

--- a/fireants/registration/abstract.py
+++ b/fireants/registration/abstract.py
@@ -156,6 +156,15 @@ class AbstractRegistration(ABC):
                 logger.warning("fireants_fused_ops not available, falling back to non-fused LocalNormalizedCrossCorrelationLoss")
                 self.loss_fn = LocalNormalizedCrossCorrelationLoss(kernel_type=cc_kernel_type, spatial_dims=self.dims,
                                                                    kernel_size=cc_kernel_size, reduction=reduction, **loss_params)
+        elif loss_type == 'fused_lncc':
+            try:
+                from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+                self.loss_fn = FusedLNCCLoss(spatial_dims=self.dims,
+                                             kernel_size=cc_kernel_size, reduction=reduction, **loss_params)
+            except ImportError:
+                logger.warning("fused_lncc not available, falling back to non-fused LocalNormalizedCrossCorrelationLoss")
+                self.loss_fn = LocalNormalizedCrossCorrelationLoss(kernel_type=cc_kernel_type, spatial_dims=self.dims,
+                                                                   kernel_size=cc_kernel_size, reduction=reduction, **loss_params)
         elif loss_type == 'fusedmi':
             try:
                 from fireants.losses.fusedmi import FusedGlobalMutualInformationLoss

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
     "pytest"
 ]
 
+[project.optional-dependencies]
+# Fast fused rectangular-LNCC backend; enable with loss_type='fused_lncc'.
+fused_lncc = ["fused_lncc"]
+
 [build-system]
 requires = ["hatchling>=1.21.0"]
 build-backend = "hatchling.build"

--- a/tests/test_fused_lncc_backend.py
+++ b/tests/test_fused_lncc_backend.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 Rohit Jena. All rights reserved.
+#
+# This file is part of FireANTs, distributed under the terms of
+# the FireANTs License version 1.0. A copy of the license can be found
+# in the LICENSE file at the root of this repository.
+
+"""Tests for the optional fused_lncc LNCC backend (loss_type='fused_lncc').
+
+Skipped unless a CUDA GPU and the `fused_lncc` package are both available. The backend is
+verified to match FusedLocalNormalizedCrossCorrelationLoss (with use_ants_gradient=False, the
+exact gradient) in forward value and gradient, and to refuse the configurations it does not
+support.
+"""
+import importlib.util
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from fireants.losses.fusedcc import FusedLocalNormalizedCrossCorrelationLoss
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="fused_lncc requires a CUDA GPU"),
+    pytest.mark.skipif(importlib.util.find_spec("fused_lncc") is None, reason="fused_lncc not installed"),
+]
+
+dev = "cuda"
+
+
+def _vol(seed, shape=(1, 1, 48, 48, 48)):
+    g = torch.Generator(device=dev).manual_seed(seed)
+    v = torch.randn(shape, device=dev, generator=g)
+    k = torch.ones(1, 1, 7, 7, 7, device=dev) / 343
+    for _ in range(2):
+        v = F.conv3d(v.reshape(-1, 1, *shape[2:]), k, padding=3).reshape(shape)
+    return (v - v.mean()) / (v.std() + 1e-6)
+
+
+def _fusedcc(k):
+    # exact gradient (use_ants_gradient=False) so it is the same algorithm as fused_lncc
+    return FusedLocalNormalizedCrossCorrelationLoss(spatial_dims=3, kernel_size=k, use_ants_gradient=False).cuda()
+
+
+@pytest.mark.parametrize("k", [3, 5, 7, 9])
+def test_forward_and_gradient_match_fusedcc(k):
+    from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+    fixed, moving = _vol(1), _vol(2)
+    mo = moving.clone().requires_grad_(True)
+    mf = moving.clone().requires_grad_(True)
+    lo = FusedLNCCLoss(spatial_dims=3, kernel_size=k)(mo, fixed)
+    lf = _fusedcc(k)(mf, fixed)
+    lo.backward(); lf.backward()
+    assert abs(lo.item() - lf.item()) < 5e-4                                    # forward value
+    assert F.cosine_similarity(mo.grad.flatten(), mf.grad.flatten(), dim=0) > 0.999   # direction
+    assert (mo.grad - mf.grad).norm() / mf.grad.norm() < 1e-2                   # magnitude
+
+
+def test_sign_and_range():
+    from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+    fixed, moving = _vol(1), _vol(2)
+    out = FusedLNCCLoss(kernel_size=7)(moving, fixed).item()
+    assert abs(out - _fusedcc(7)(moving, fixed).item()) < 5e-4                  # matches fusedcc sign+value
+    assert -1.0001 <= out <= 0.0001                                            # -mean(ncc) in [-1, 0]
+
+
+def test_batched_gradient_scale():
+    from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+    fixed, moving = _vol(1, (2, 1, 32, 32, 32)), _vol(2, (2, 1, 32, 32, 32))
+    mo = moving.clone().requires_grad_(True)
+    mf = moving.clone().requires_grad_(True)
+    FusedLNCCLoss(kernel_size=5)(mo, fixed).backward()
+    _fusedcc(5)(mf, fixed).backward()
+    assert (mo.grad - mf.grad).norm() / mf.grad.norm() < 1e-2
+
+
+def test_gradient_routes_to_grad_requiring_input():
+    from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+    fixed = _vol(1).requires_grad_(True)
+    moving = _vol(2)  # no grad
+    FusedLNCCLoss(kernel_size=7)(moving, fixed).backward()  # pred has no grad -> swap
+    assert fixed.grad is not None and fixed.grad.abs().sum() > 0
+
+
+class TestScopeGuards:
+    """Unsupported configurations must fail clearly rather than silently misbehave."""
+
+    def test_gaussian_raises(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(NotImplementedError):
+            FusedLNCCLoss(kernel_type="gaussian")
+
+    def test_non_mean_reduction_raises(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(NotImplementedError):
+            FusedLNCCLoss(reduction="sum")
+
+    def test_masked_raises(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(NotImplementedError):
+            FusedLNCCLoss(masked=True)
+
+    def test_2d_raises(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(NotImplementedError):
+            FusedLNCCLoss(spatial_dims=2)
+
+    @pytest.mark.parametrize("bad_k", [4, 11])
+    def test_unsupported_kernel_size_raises(self, bad_k):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(ValueError):
+            FusedLNCCLoss(kernel_size=bad_k)
+
+    def test_symmetric_gradient_raises(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        a = _vol(1).requires_grad_(True)
+        b = _vol(2).requires_grad_(True)
+        with pytest.raises(NotImplementedError):
+            FusedLNCCLoss(kernel_size=7)(a, b)
+
+
+class TestMultiScale:
+    """kernel_size may be a list, one entry per registration scale."""
+
+    def test_kernel_size_switches_per_scale(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        loss = FusedLNCCLoss(kernel_size=[7, 5, 3])
+        loss.set_scales([4, 2, 1])
+        loss.set_current_scale_and_iterations(2, 10)
+        assert loss.kernel_size == 5 and loss.get_image_padding() == 2
+        loss.set_current_scale_and_iterations(1, 10)
+        assert loss.kernel_size == 3 and loss.get_image_padding() == 1
+
+    def test_list_length_must_match_scales(self):
+        from fireants.losses.fused_lncc_backend import FusedLNCCLoss
+        with pytest.raises(AssertionError):
+            FusedLNCCLoss(kernel_size=[7, 5]).set_scales([4, 2, 1])
+
+
+def test_dispatcher_selects_backend_and_registers():
+    """loss_type='fused_lncc' builds the backend and registers as well as fusedcc."""
+    import numpy as np
+    import SimpleITK as sitk
+    from fireants.io.image import Image, BatchedImages
+    from fireants.registration.greedy import GreedyRegistration
+
+    S = 48
+    fixed = _vol(1, (1, 1, S, S, S))
+    disp = _vol(7, (1, 3, S, S, S)) * 0.06
+    grid = F.affine_grid(torch.eye(3, 4, device=dev)[None], (1, 1, S, S, S), align_corners=True)
+    moving = F.grid_sample(fixed, grid + disp.permute(0, 2, 3, 4, 1), padding_mode="border", align_corners=True)
+    fnp, mnp = fixed.cpu().numpy()[0, 0], moving.cpu().numpy()[0, 0]
+
+    def reg(loss_type, loss_params):
+        fb = BatchedImages([Image(sitk.GetImageFromArray(fnp.astype(np.float32)), device=dev)])
+        mb = BatchedImages([Image(sitk.GetImageFromArray(mnp.astype(np.float32)), device=dev)])
+        r = GreedyRegistration(scales=[2, 1], iterations=[25, 25], fixed_images=fb, moving_images=mb,
+                               loss_type=loss_type, optimizer="Adam", optimizer_lr=0.2, loss_params=loss_params,
+                               cc_kernel_size=5, smooth_warp_sigma=0.25, smooth_grad_sigma=0.5, progress_bar=False)
+        r.optimize()
+        moved = r.evaluate(fb, mb).detach()
+        return r, F.mse_loss(moved, fixed).item()
+
+    r_ours, mse_ours = reg("fused_lncc", {})
+    _, mse_fa = reg("fusedcc", {"use_ants_gradient": False})
+    assert type(r_ours.loss_fn).__name__ == "FusedLNCCLoss"          # dispatcher built our backend
+    assert mse_ours < 0.5                                            # registration actually converged
+    assert abs(mse_ours - mse_fa) < 0.1 * mse_fa                     # matches fusedcc quality


### PR DESCRIPTION
# Add an optional `fused_lncc` LNCC backend

Wires up [`fused_lncc`](https://github.com/minsuk00/fused-lncc) as an optional LNCC backend,
selectable via `loss_type='fused_lncc'`. It is a standalone fused rectangular-LNCC CUDA kernel;
this PR plugs it in as an opt-in dependency that falls back to `cc` when not installed, so existing
behavior is unchanged.

## Changes
- `fireants/losses/fused_lncc_backend.py` — `FusedLNCCLoss`, a thin adapter matching the
  `FusedLocalNormalizedCrossCorrelationLoss` interface (constructor args, `forward`, and the
  multiscale hooks). Calls the kernel; no new math.
- `fireants/registration/abstract.py` — a `loss_type == 'fused_lncc'` branch mirroring the
  `fusedcc` branch (optional import + fallback to `cc`).
- `pyproject.toml` — optional dependency (`pip install fireants[fused_lncc]`).
- `tests/test_fused_lncc_backend.py` — auto-skips without CUDA or the package.

## Behavior
Returns `-mean(ncc)`, the same convention as `fusedcc`. Uses the exact gradient (matches
`FusedLocalNormalizedCrossCorrelationLoss(use_ants_gradient=False)`), rescaled so the same optimizer
hyperparameters converge identically. Scope is deliberately narrow: rectangular only, k ∈ {3,5,7,9},
mean reduction, pred-only gradient, single GPU. Other configurations (gaussian, masking, sum/none
reduction, symmetric/SyN gradients, grid-parallel sharding) raise a clear error pointing to `fusedcc`.

## Performance (A40)
The loss kernel is ~3.4× faster / ~3× lighter than `fusedcc`. End-to-end registration is ~1.1–1.3×
per iteration (the loss is ~38% of a fused step) and ~2.7× against the non-fused `cc` path, at equal
VRAM and equal registration quality.

## Tests
`pytest tests/test_fused_lncc_backend.py` passes on an A40: forward and gradient parity vs `fusedcc`
(k=3/5/7/9), sign/range, batched gradient scale, gradient routing, scope guards, multiscale hooks,
and an end-to-end registration through the dispatcher.